### PR TITLE
MYBLDR-7809: Add Dialog component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,18 +1,34 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.mdx",
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [
     "@storybook/addon-onboarding",
     "@storybook/addon-docs",
-    "@storybook/addon-themes"
+    "@storybook/addon-themes",
   ],
-  "framework": {
-    "name": "@storybook/react-vite",
-    "options": {}
-  }
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      // Speeds up Storybook build time
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false,
+      },
+      // Makes union prop types like variant and size appear as select controls
+      shouldExtractLiteralValuesFromEnum: true,
+      // Makes string and boolean types that can be undefined appear as inputs and switches
+      shouldRemoveUndefinedFromOptional: true,
+      // Filter out third-party props from node_modules except @mui packages
+      propFilter: (prop) =>
+        prop.parent
+          ? !/node_modules\/(?!@mui)/.test(prop.parent.fileName)
+          : true,
+    },
+  },
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -17,6 +17,29 @@ export const decorators = [
 const preview: Preview = {
   parameters: {
     controls: {
+      sort: "requiredFirst",
+      exclude: new RegExp(
+        [
+          // on[Something] handlers
+          "on[A-Z].*",
+          // aria labels
+          "aria-.*",
+          // Customization props
+          ".*[Cc]omponent",
+          ".*Props",
+          "slots",
+          "sx",
+          "ref",
+          ".*Ref",
+          "classes",
+          "style",
+          "render[A-Z].*",
+          "unstable_.*",
+          "id",
+        ]
+          .map((selector) => `^${selector}$`)
+          .join("|"),
+      ),
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/i,

--- a/src/Autocomplete.stories.tsx
+++ b/src/Autocomplete.stories.tsx
@@ -19,7 +19,6 @@ export const AutocompleteWithLabel: Story = {
   argTypes: {
     sx: {
       table: {
-        // Hide sx from control panel
         disable: true,
       },
     },

--- a/src/BldrThemeProvider.tsx
+++ b/src/BldrThemeProvider.tsx
@@ -29,7 +29,7 @@ declare module "@mui/material/styles/createTypography" {
   }
 }
 
-const theme = createTheme({
+let theme = createTheme({
   palette: {
     primary: {
       main: "#1D6BCD",
@@ -65,6 +65,9 @@ const theme = createTheme({
       gridRowHover: "#E3E4E5",
     },
   },
+});
+
+theme = createTheme(theme, {
   typography: {
     fontFamily: "Roboto",
     fontWeightRegular: 400,
@@ -102,6 +105,7 @@ const theme = createTheme({
     body2: {
       fontSize: "14px",
       lineHeight: "20px",
+      color: theme.palette.text.secondary,
     },
     button: {
       textTransform: "none",
@@ -117,11 +121,12 @@ export const BldrThemeProvider = ({ children }: PropsWithChildren) => {
           ...theme,
           components: {
             MuiDialogTitle: {
+              defaultProps: {
+                component: "h6",
+              },
               styleOverrides: {
                 root: {
-                  fontWeight: 600,
-                  fontSize: "20px",
-                  paddingBottom: "32px",
+                  paddingRight: theme.spacing(8),
                 },
               },
             },

--- a/src/BldrThemeProvider.tsx
+++ b/src/BldrThemeProvider.tsx
@@ -138,6 +138,14 @@ export const BldrThemeProvider = ({ children }: PropsWithChildren) => {
               },
             },
             MuiButton: {
+              styleOverrides: {
+                root: {
+                  boxShadow: "none",
+                  "&:hover": {
+                    boxShadow: "none",
+                  },
+                },
+              },
               variants: [
                 {
                   props: { variant: "contained", color: "secondary" },

--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Button } from "@mui/material";
+import { Button } from "./Button";
 
 const meta = {
   title: "Button",

--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "@mui/material";
+
+const meta = {
+  title: "Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const BaseButton: Story = {
+  args: {
+    children: "Label",
+    variant: "contained",
+  },
+};

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -4,7 +4,7 @@ import {
 } from "@mui/material";
 import { useIsPromisePending } from "./useIsPromisePending";
 
-export type ButtonProps = MuiButtonProps;
+export interface ButtonProps extends MuiButtonProps {}
 
 export const Button = ({ loading, onClick, ...props }: ButtonProps) => {
   const [isPending, observePromise] = useIsPromisePending();

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,0 +1,20 @@
+import {
+  Button as MuiButton,
+  ButtonProps as MuiButtonProps,
+} from "@mui/material";
+import { useIsPromisePending } from "./useIsPromisePending";
+
+export type ButtonProps = MuiButtonProps;
+
+export const Button = ({ loading, onClick, ...props }: ButtonProps) => {
+  const [isPending, observePromise] = useIsPromisePending();
+  const isLoading = isPending || loading;
+
+  return (
+    <MuiButton
+      {...props}
+      loading={isLoading}
+      onClick={onClick ? observePromise(onClick) : onClick}
+    />
+  );
+};

--- a/src/Dialog.stories.tsx
+++ b/src/Dialog.stories.tsx
@@ -15,6 +15,9 @@ export default meta;
 
 type Story = StoryObj<typeof Dialog>;
 
+const LOREM =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.";
+
 export const BaseDialog: Story = {
   argTypes: {
     disablePortal: {
@@ -28,11 +31,55 @@ export const BaseDialog: Story = {
     open: true,
     title: "Title",
     subtitle: "Subtitle",
-    content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    content: LOREM,
+    actionDetails: "Details",
     primaryAction: {
       onClick: () => alert("Clicked!"),
       text: "Submit",
+    },
+  },
+};
+
+export const ScrollDialog: Story = {
+  argTypes: {
+    disablePortal: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    disablePortal: true,
+    open: true,
+    title: "Title",
+    content: Array(5).fill(LOREM).join(" "),
+    showDivider: true,
+  },
+};
+
+export const LoadingDialog: Story = {
+  argTypes: {
+    disablePortal: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    disablePortal: true,
+    open: true,
+    title: "Title",
+    subtitle: "Subtitle",
+    content: LOREM,
+    primaryAction: {
+      onClick: async () =>
+        await new Promise((resolve) => setTimeout(resolve, 1000)),
+      text: "Submit",
+    },
+    tertiaryAction: {
+      onClick: async () =>
+        await new Promise((resolve) => setTimeout(resolve, 1000)),
+      text: "Tertiary",
     },
   },
 };

--- a/src/Dialog.stories.tsx
+++ b/src/Dialog.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Dialog } from "./Dialog";
+
+const meta = {
+  title: "Dialog",
+  component: Dialog,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof Dialog>;
+
+export const BaseDialog: Story = {
+  argTypes: {
+    disablePortal: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  args: {
+    disablePortal: true,
+    open: true,
+    title: "Title",
+    subtitle: "Subtitle",
+    content:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    primaryAction: {
+      onClick: () => alert("Clicked!"),
+      text: "Submit",
+    },
+  },
+};

--- a/src/Dialog.stories.tsx
+++ b/src/Dialog.stories.tsx
@@ -68,6 +68,7 @@ export const LoadingDialog: Story = {
   args: {
     disablePortal: true,
     open: true,
+    showLoadingOverlay: true,
     title: "Title",
     subtitle: "Subtitle",
     content: LOREM,

--- a/src/Dialog.stories.tsx
+++ b/src/Dialog.stories.tsx
@@ -35,7 +35,7 @@ export const BaseDialog: Story = {
     actionDetails: "Details",
     primaryAction: {
       onClick: () => alert("Clicked!"),
-      text: "Submit",
+      label: "Submit",
     },
   },
 };
@@ -53,7 +53,6 @@ export const ScrollDialog: Story = {
     open: true,
     title: "Title",
     content: Array(5).fill(LOREM).join(" "),
-    showDivider: true,
   },
 };
 
@@ -75,12 +74,12 @@ export const LoadingDialog: Story = {
     primaryAction: {
       onClick: async () =>
         await new Promise((resolve) => setTimeout(resolve, 1000)),
-      text: "Submit",
+      label: "Submit",
     },
     tertiaryAction: {
       onClick: async () =>
         await new Promise((resolve) => setTimeout(resolve, 1000)),
-      text: "Tertiary",
+      label: "Tertiary",
     },
   },
 };

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -28,7 +28,11 @@ export interface DialogProps
     text: string;
   };
   dismissActionText?: string;
-  tertiaryAction?: React.ReactNode;
+  tertiaryAction?: {
+    onClick: () => Promise<void> | void;
+    text: string;
+  };
+  actionDetails?: React.ReactNode;
 }
 
 export const Dialog = ({
@@ -39,7 +43,8 @@ export const Dialog = ({
   actions,
   primaryAction,
   dismissActionText = "Cancel",
-  tertiaryAction = null,
+  tertiaryAction,
+  actionDetails,
   ...props
 }: DialogProps) => {
   return (
@@ -65,7 +70,12 @@ export const Dialog = ({
       {content && <DialogContent>{content}</DialogContent>}
       {children}
       <DialogActions>
-        {tertiaryAction}
+        {actionDetails}
+        {tertiaryAction && (
+          <Button variant="text" onClick={tertiaryAction.onClick}>
+            {tertiaryAction.text}
+          </Button>
+        )}
         <Button
           sx={{ marginLeft: "auto" }}
           variant="outlined"

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,7 +1,5 @@
 import { Close } from "@mui/icons-material";
 import {
-  Button,
-  ButtonProps,
   Dialog as MuiDialog,
   DialogActions,
   DialogContent,
@@ -9,7 +7,10 @@ import {
   DialogTitle,
   IconButton,
   Typography,
+  Box,
 } from "@mui/material";
+import { useIsPromisePending } from "./useIsPromisePending";
+import { Button, ButtonProps } from "./Button";
 
 export interface DialogProps
   extends Omit<MuiDialogProps, "onClose" | "title" | "content"> {
@@ -33,6 +34,8 @@ export interface DialogProps
     text: string;
   };
   actionDetails?: React.ReactNode;
+  showDivider: boolean;
+  isLoading?: boolean;
 }
 
 export const Dialog = ({
@@ -45,11 +48,17 @@ export const Dialog = ({
   dismissActionText = "Cancel",
   tertiaryAction,
   actionDetails,
+  showDivider,
+  isLoading,
   ...props
 }: DialogProps) => {
+  const [isPending, observePromise] = useIsPromisePending();
+  const isDisabled = isPending || isLoading;
+
   return (
     <MuiDialog {...props}>
       <IconButton
+        disabled={isDisabled}
         aria-label="close"
         onClick={(e) => props.onClose?.(e, "cancelClick")}
         sx={{
@@ -67,17 +76,24 @@ export const Dialog = ({
           {subtitle && <Typography variant="body2">{subtitle}</Typography>}
         </DialogTitle>
       )}
-      {content && <DialogContent>{content}</DialogContent>}
+      {content && (
+        <DialogContent dividers={showDivider}>{content}</DialogContent>
+      )}
       {children}
       <DialogActions>
-        {actionDetails}
         {tertiaryAction && (
-          <Button variant="text" onClick={tertiaryAction.onClick}>
+          <Button
+            disabled={isDisabled}
+            variant="text"
+            onClick={observePromise(tertiaryAction.onClick)}
+          >
             {tertiaryAction.text}
           </Button>
         )}
+        {actionDetails}
+        <Box sx={{ marginRight: "auto" }} />
         <Button
-          sx={{ marginLeft: "auto" }}
+          disabled={isDisabled}
           variant="outlined"
           color="secondary"
           onClick={(e) => props.onClose?.(e, "cancelClick")}
@@ -86,9 +102,10 @@ export const Dialog = ({
         </Button>
         {primaryAction && (
           <Button
+            disabled={isDisabled}
             variant="contained"
             color={primaryAction.color}
-            onClick={primaryAction.onClick}
+            onClick={observePromise(primaryAction.onClick)}
           >
             {primaryAction.text}
           </Button>

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -22,7 +22,6 @@ export interface DialogProps
   title?: React.ReactNode;
   subtitle?: React.ReactNode;
   content?: React.ReactNode;
-  actions?: ButtonProps[];
   onSubmit?: () => Promise<void> | void;
   primaryAction?: {
     color?: ButtonProps["color"];
@@ -45,7 +44,6 @@ export const Dialog = ({
   subtitle,
   children,
   content,
-  actions,
   primaryAction,
   dismissActionText = "Cancel",
   tertiaryAction,

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   Typography,
   Box,
+  CircularProgress,
 } from "@mui/material";
 import { useIsPromisePending } from "./useIsPromisePending";
 import { Button, ButtonProps } from "./Button";
@@ -35,6 +36,7 @@ export interface DialogProps
   };
   actionDetails?: React.ReactNode;
   showDivider: boolean;
+  showLoadingOverlay?: boolean;
   isLoading?: boolean;
 }
 
@@ -49,16 +51,35 @@ export const Dialog = ({
   tertiaryAction,
   actionDetails,
   showDivider,
+  showLoadingOverlay,
   isLoading,
   ...props
 }: DialogProps) => {
   const [isPending, observePromise] = useIsPromisePending();
-  const isDisabled = isPending || isLoading;
+  const isLoadingOrPending = isPending || isLoading;
 
   return (
     <MuiDialog {...props}>
+      {isLoadingOrPending && showLoadingOverlay && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: "rgba(255, 255, 255, 0.7)", // Semi-transparent white background
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            zIndex: 1,
+          }}
+        >
+          <CircularProgress size={50} />
+        </Box>
+      )}
       <IconButton
-        disabled={isDisabled}
+        disabled={isLoadingOrPending}
         aria-label="close"
         onClick={(e) => props.onClose?.(e, "cancelClick")}
         sx={{
@@ -83,7 +104,7 @@ export const Dialog = ({
       <DialogActions>
         {tertiaryAction && (
           <Button
-            disabled={isDisabled}
+            disabled={isLoadingOrPending}
             variant="text"
             onClick={observePromise(tertiaryAction.onClick)}
           >
@@ -93,7 +114,7 @@ export const Dialog = ({
         {actionDetails}
         <Box sx={{ marginRight: "auto" }} />
         <Button
-          disabled={isDisabled}
+          disabled={isLoadingOrPending}
           variant="outlined"
           color="secondary"
           onClick={(e) => props.onClose?.(e, "cancelClick")}
@@ -102,7 +123,7 @@ export const Dialog = ({
         </Button>
         {primaryAction && (
           <Button
-            disabled={isDisabled}
+            disabled={isLoadingOrPending}
             variant="contained"
             color={primaryAction.color}
             onClick={observePromise(primaryAction.onClick)}

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,0 +1,89 @@
+import { Close } from "@mui/icons-material";
+import {
+  Button,
+  ButtonProps,
+  Dialog as MuiDialog,
+  DialogActions,
+  DialogContent,
+  DialogProps as MuiDialogProps,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+
+export interface DialogProps
+  extends Omit<MuiDialogProps, "onClose" | "title" | "content"> {
+  onClose: (
+    event?: any,
+    reason?: "backdropClick" | "escapeKeyDown" | "cancelClick",
+  ) => void;
+  title?: React.ReactNode;
+  subtitle?: React.ReactNode;
+  content?: React.ReactNode;
+  actions?: ButtonProps[];
+  onSubmit?: () => Promise<void> | void;
+  primaryAction?: {
+    color?: ButtonProps["color"];
+    onClick: () => Promise<void> | void;
+    text: string;
+  };
+  dismissActionText?: string;
+  tertiaryAction?: React.ReactNode;
+}
+
+export const Dialog = ({
+  title,
+  subtitle,
+  children,
+  content,
+  actions,
+  primaryAction,
+  dismissActionText = "Cancel",
+  tertiaryAction = null,
+  ...props
+}: DialogProps) => {
+  return (
+    <MuiDialog {...props}>
+      <IconButton
+        aria-label="close"
+        onClick={(e) => props.onClose?.(e, "cancelClick")}
+        sx={{
+          position: "absolute",
+          right: 10,
+          top: 10,
+          color: "black",
+        }}
+      >
+        <Close />
+      </IconButton>
+      {title && (
+        <DialogTitle>
+          {title}
+          {subtitle && <Typography variant="body2">{subtitle}</Typography>}
+        </DialogTitle>
+      )}
+      {content && <DialogContent>{content}</DialogContent>}
+      {children}
+      <DialogActions>
+        {tertiaryAction}
+        <Button
+          sx={{ marginLeft: "auto" }}
+          variant="outlined"
+          color="secondary"
+          onClick={(e) => props.onClose?.(e, "cancelClick")}
+        >
+          {dismissActionText}
+        </Button>
+        {primaryAction && (
+          <Button
+            variant="contained"
+            color={primaryAction.color}
+            onClick={primaryAction.onClick}
+          >
+            {primaryAction.text}
+          </Button>
+        )}
+      </DialogActions>
+    </MuiDialog>
+  );
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,5 +5,7 @@ export * from "@mui/material";
 // native MUI components
 import { Autocomplete, AutocompleteProps } from "./Autocomplete";
 import { TextField, TextFieldProps } from "./TextField";
-export { Autocomplete, TextField };
-export type { AutocompleteProps, TextFieldProps };
+import { Dialog, DialogProps } from "./Dialog";
+import { Button, ButtonProps } from "./Button";
+export { Autocomplete, TextField, Dialog, Button };
+export type { AutocompleteProps, TextFieldProps, DialogProps, ButtonProps };

--- a/src/useIsPromisePending.ts
+++ b/src/useIsPromisePending.ts
@@ -1,0 +1,26 @@
+import { useCallback, useMemo, useState } from "react";
+
+// Useful for connecting the pending state of a promise to React lifecycle
+// Abstracts away the pattern of `useState` hooks that manually set and unset a loading status
+export const useIsPromisePending = () => {
+  const [isPending, setIsPending] = useState(false);
+  const observePromise = useCallback(
+    <Result, Args extends any[]>(
+      fn: (...args: Args) => Promise<Result> | Result,
+    ) =>
+      async (...args: Args) => {
+        try {
+          setIsPending(true);
+          return await fn(...args);
+        } finally {
+          setIsPending(false);
+        }
+      },
+    [setIsPending],
+  );
+
+  return useMemo(
+    () => [isPending, observePromise] as const,
+    [isPending, observePromise],
+  );
+};

--- a/src/useIsScrollable.ts
+++ b/src/useIsScrollable.ts
@@ -1,0 +1,26 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+export const useIsScrollable = () => {
+  const ref = useRef<HTMLElement>(null);
+  const [isScrollable, setIsScrollable] = useState(false);
+
+  useLayoutEffect(() => {
+    const observer = new ResizeObserver(() => {
+      if (ref.current) {
+        setIsScrollable(ref.current.scrollHeight > ref.current.clientHeight);
+      }
+    });
+
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+
+    return () => {
+      if (ref.current) {
+        observer.unobserve(ref.current);
+      }
+    };
+  }, []);
+
+  return [isScrollable, ref] as const;
+};


### PR DESCRIPTION
- Updated Dialog props to be a bit more constrained (actions -> primaryAction, dismissAction, tertiaryAction/actionDetails)
  - I talked with Diego and it sounded like this taxonomy should cover most use cases. 
- I will plan on adding more stories, but I'd like to see how this gets used before investing more time into that
- I decided to make showDividers a prop rather than calculating it based on scroll. Seems like this should work fine, but maybe I'm not accounting for something
- Added the Button component for now. It will get more updates in a future PR
- Added control/doc generation from TS